### PR TITLE
I18N Issues

### DIFF
--- a/heic-support.php
+++ b/heic-support.php
@@ -149,8 +149,8 @@ add_filter( 'wp_generate_attachment_metadata', 'heic_support_populate_meta', 10,
 function heic_support_add_menu() {
 	add_submenu_page(
 		'upload.php',
-		__( 'HEIC Support', 'heic-support' ),
-		__( 'HEIC Support', 'heic-support' ),
+		_x( 'HEIC Support', 'UI Strings', 'heic-support' ),
+		_x( 'HEIC Support', 'UI Strings', 'heic-support' ),
 		'upload_files',
 		'heic-support',
 		'heic_support_page_content'
@@ -178,7 +178,7 @@ function heic_support_imagemagick_version() {
 function heic_support_page_content() {
 	?>
 <div class="wrap">
-	<h2><?php esc_html_e( 'HEIC Support', 'heic-support' ); ?></h2>
+	<h2><?php echo esc_html_x( 'HEIC Support', 'UI Strings', 'heic-support' ); ?></h2>
 	<p>
 	<?php
 	esc_html_e( 'This plugin only works on servers running ImageMagick 7 or above. ', 'heic-support' );
@@ -207,7 +207,7 @@ function heic_support_page_content() {
 			}
 		} catch ( ImagickException $ie ) {
 			// "Fatal error: Uncaught ImagickException: no decode delegate for this image format `HEIC'".
-			$msg = 'no decode delegate for this image format `HEIC\'';
+			$msg = __('no decode delegate for this image format \'HEIC\'', 'heic-support' );
 			if ( false !== strpos( $ie->getMessage(), $msg ) ) {
 				esc_html_e( 'ImageMagick is installed, but does not support HEIC. Oldest version with HEIC support is 7.0.8-46. Installed version is ', 'heic-support' );
 				echo esc_html( heic_support_imagemagick_version() );

--- a/heic-support.php
+++ b/heic-support.php
@@ -207,7 +207,7 @@ function heic_support_page_content() {
 			}
 		} catch ( ImagickException $ie ) {
 			// "Fatal error: Uncaught ImagickException: no decode delegate for this image format `HEIC'".
-			$msg = __('no decode delegate for this image format \'HEIC\'', 'heic-support' );
+			$msg = 'no decode delegate for this image format `HEIC\'';
 			if ( false !== strpos( $ie->getMessage(), $msg ) ) {
 				esc_html_e( 'ImageMagick is installed, but does not support HEIC. Oldest version with HEIC support is 7.0.8-46. Installed version is ', 'heic-support' );
 				echo esc_html( heic_support_imagemagick_version() );


### PR DESCRIPTION
- Same [related topic](https://wordpress.org/support/topic/i18n-issues-10/) on the support forum. Sorry about the duplicated topic.
- **HEIC Support** is its plugin name but has a precise meaning when this string shows on the WordPress Dashboard. In some languages, like **zh_TW**, the translators don’t translate the plugin’s name but need to translate the plugin’s UI, so I made some modifications for this issue.
- There is one message that can be translated.